### PR TITLE
Fixed an issue with union types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-remote-graphql-schemas",
-  "version": "0.1.20",
+  "version": "0.1.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-remote-graphql-schemas",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Merge GraphQL remote executable schemas using directive hints",
   "keywords": [
     "graphql",

--- a/src/merge-remote-schemas.ts
+++ b/src/merge-remote-schemas.ts
@@ -253,6 +253,7 @@ function recreateUnionType(type: GraphQLUnionType, newTypes: NewTypesMap) {
     astNode: type.astNode,
     extensionASTNodes: type.extensionASTNodes,
     types: () => type.getTypes().map((t) => (newTypes[t.name] || t) as GraphQLObjectType),
+    resolveType: type.resolveType,
   });
 }
 


### PR DESCRIPTION
`recreateUnionType` was previously skipping the `resolveType` method which is essential for a union type resolver to work. graphql queries on union types borks at runtime asking "where did the `resolveType` go?"